### PR TITLE
adding the semicolon at the end

### DIFF
--- a/js/jquery.parallax-scroll.js
+++ b/js/jquery.parallax-scroll.js
@@ -182,4 +182,4 @@ var ParallaxScroll = {
             this._requestAnimationFrame($.proxy(this._onScroll, this, false));
         }
     }
-}
+};


### PR DESCRIPTION
the missing semicolon at the end is causing errors when compress/minify